### PR TITLE
Make first part of render method work by adjusting fired_upon?

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,10 +1,11 @@
 class Cell
   require 'pry'
-  attr_reader :coordinate, :ship
+  attr_reader :coordinate, :ship, :fired_at
 
   def initialize(coordinate)
     @coordinate = coordinate
     @ship = nil
+    @fired_at = false
   end
 
   def empty?
@@ -17,19 +18,34 @@ class Cell
   end
 
   def fired_upon?
-    return false if @ship.health == ship.length
-    true
+    if !empty?
+      return false if @ship.health == ship.length
+      true
+    else
+      return false if fired_at != true
+      true
+    end
   end
 
   def fire_upon
-    ship.hit
-  end
-
-  def render
-    if @ship == nil && @coordinate != coordinate
-      "."
-    elsif @ship == nil && @coordinate 
-      "M"
+    @fired_at = true
+    if !empty?
+      ship.hit
     end
   end
+
+
+  def render
+    if fired_upon? == false
+      "."
+    elsif fired_upon? && empty?
+      "M"
+    # elsif fired_upon? == true && ship.sunk? == true
+    #   "X"
+    # elsif fired_upon? == true && empty? == false
+    #   "H"
+    end
+  end
+
+
 end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Cell do
     expect(cell.empty?).to eq(false)
   end
 
-  it 'is has been fired upon' do
+  it 'is has been fired upon & not hit' do
     cell = Cell.new("B4")
     cruiser = Ship.new("Cruiser", 3)
 
@@ -51,19 +51,7 @@ RSpec.describe Cell do
     expect(cell.fired_upon?).to eq(false)
   end
 
-  it 'is has not been fired upon' do
-    cell = Cell.new("B4")
-    cruiser = Ship.new("Cruiser", 3)
-
-    cell.place_ship(cruiser)
-
-    expect(cell.fired_upon?).to eq(false)
-
-    cell.fire_upon
-    expect(cell.ship.health).to eq(2)
-  end
-
-  it 'is has been fired upon' do
+  it 'is has been fired upon & hit' do
     cell = Cell.new("B4")
     cruiser = Ship.new("Cruiser", 3)
 
@@ -71,6 +59,7 @@ RSpec.describe Cell do
 
     cell.fire_upon
     expect(cell.ship.health).to eq(2)
+    # binding.pry
     expect(cell.fired_upon?).to eq(true)
   end
 
@@ -78,6 +67,7 @@ RSpec.describe Cell do
     cell_1 = Cell.new("B4")
 
     cell_1.render
+    # binding.pry
 
     expect(cell_1.render).to eq(".")
 


### PR DESCRIPTION
Hello!
Please see some additions to our cell class:

- changed some of the syntax of both the `fired_upon?` and `fire_upon` methods to accommodate conditions for ' . ' and 'M' in the render method
- added the instance variable `@fired_at` (we can rename as needed) to accommodate conditions (to keep it from flip flopping between ' . ' and 'M'/

Thank you!